### PR TITLE
Remove Linux-only OS restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
       "email": "fred.eisele@vanderbilt.edu"
     }
   ],
-  "os": [
-    "linux"
-  ],
   "optionalDependencies": {},
   "preferGlobal": true,
   "private": false,


### PR DESCRIPTION
Previously, OS was restricted to only `linux`. However cytoscape.js does not appear to have any os restrictions defined in it's [`package.json`](https://github.com/cytoscape/cytoscape.js/blob/master/package.json). Addresses issue #1. 

I have tested it on my OSX 10.11.5 machine, npm v3.3.12, node v5.4.0, tsc (typescript compiler) v2.1.5. All previous `Cannot find name 'cytoscape'` errors have disappeared.

